### PR TITLE
Make TLND go 100x faster

### DIFF
--- a/src/TLND/CMST_dfs_OLD.py
+++ b/src/TLND/CMST_dfs_OLD.py
@@ -102,21 +102,20 @@ def depthFirstSet(node1,node2,root,segList,distDict):
                     firstNode.setWeight(v.getWeight()+distDict[(v.getID(),firstNode.getID())])
             to_visit.extend(vNeighbors)
 
-def maxDistFromNode(node1,root,treeSegments,distDict):
+def maxDistFromNode(node1,root,treeSegments,distDict,segList):
     """
     Given a starting vertex, do a depth-first search and find the furthest node to that vertex
     """
-    segList=buildAssocDict(treeSegments.values())
     to_visit = []  # a list can be used as a stack in Python
-    visited=[]
-    
+    visited = set()
+
     tempWeightByNode={}
     to_visit.append(node1)
     tempWeightByNode[node1.getID()]=0
-    while len(to_visit)!= 0:
+    while to_visit:
         v = to_visit.pop()
         if v not in visited:
-            visited.append(v)
+            visited.add(v)
             vNeighbors=[]
             for seg in segList[v.getID()]:
                 firstNode,secondNode=seg.getNodes()
@@ -203,8 +202,9 @@ def CMST(households,capacity,root):
 
         #tree updated after weights are set
         treeSegments[(node1.getID(), node2.getID())]=network.Seg(SegID,node1, node2,distDict[(node1.getID(),node2.getID())])
-      
-        
+        segList = buildAssocDict(treeSegments.values())
+
+
         # Update dictionaries
         nodesByBranchNode[branchNodeByNode[node2]].extend(nodesByBranchNode.pop(branchNodeByNode[node1]))
         for node in nodesByBranchNode[branchNodeByNode[node2]]:
@@ -213,11 +213,11 @@ def CMST(households,capacity,root):
         # Rebuilt TStore & select maxT object
         for node1 in households_Copy:  #
             #print "node1", node1
+            maxDistFromNode1=maxDistFromNode(node1,root_Copy,treeSegments,distDict,segList)
             for node2 in households_Copy:
                 if node1==node2 or branchNodeByNode[node1]==branchNodeByNode[node2]:
                     continue
                 else:
-                    maxDistFromNode1=maxDistFromNode(node1,root_Copy,treeSegments,distDict)
                     #print "maaxx",maxDistFromNode1
                     if (node2.getWeight()+distDict[node1.getID(),node2.getID()]+maxDistFromNode1<=capacity): #1 2ye baslansa ne olur?
                         #print "TTTTT", Tvalue

--- a/src/TLND/network.py
+++ b/src/TLND/network.py
@@ -215,42 +215,23 @@ class Seg:
         self._weight = weight
         self._demand = demand
 
-    def __lt__(self, other):
-        if self.getWeight() < other.getWeight():
-            return True
-        else:
-            return False
-
-    def __le__(self, other):
-        if self.getWeight() <= other.getWeight():
-            return True
-        else:
-            return False
-
     def __eq__(self, other):
-        'Two segments are defined as equal iff they have identical IDs.'
-        if self.getID() == other.getID():
-            return True
-        else:
-            return False
+        return self._ID == other._ID
 
     def __ne__(self, other):
-        if self.getID() != other.getID():
-            return True
-        else:
-            return False
-    
+        return self._ID != other._ID
+
+    def __lt__(self, other):
+        return self._weight < other._weight
+
+    def __le__(self, other):
+        return self._weight <= other._weight
+
     def __gt__(self, other):
-        if self.getWeight() > other.getWeight():
-            return True
-        else:
-            return False
+        return self._weight > other._weight
 
     def __ge__(self, other):
-        if self.getWeight() >= other.getWeight():
-            return True
-        else:
-            return False
+        return self._weight >= other._weight
 
     def __repr__(self):
         id = self.getID()
@@ -269,8 +250,8 @@ class Seg:
         return "(%(id)s, %(node1)s, %(node2)s, %(weight)s, %(demand)s)" %vars()
 
     def __hash__(self):
-        return hash(str(self.getID()))
-    
+        return hash(self._ID)
+
     @property
     def __geo_interface__(self):
         'Provides an interface to allow conversion for use with Shapely.'
@@ -312,7 +293,7 @@ class Node:
         self._demand = value5
 
     def __hash__(self):
-        return hash(str(self.getID()))
+        return hash(self._id)
 
     def __repr__(self):
         id = self.getID()
@@ -330,41 +311,23 @@ class Node:
         demand = self.getDemand()
         return "(%(id)s, %(x)s, %(y)s, %(weight)s, %(demand)s)" %vars()
 
-    def __lt__(self, other):
-        if self.getWeight() < other.getWeight():
-            return True
-        else:
-            return False
-
-    def __le__(self, other):
-        if self.getWeight() <= other.getWeight():
-            return True
-        else:
-            return False
-
     def __eq__(self, other):
-        if self.getID() == other.getID():
-            return True
-        else:
-            return False
+        return self._id == other._id
 
     def __ne__(self, other):
-        if self.getID() != other.getID():
-            return True
-        else:
-            return False
-    
+        return self._id != other._id
+
+    def __lt__(self, other):
+        return self._weight < other._weight
+
+    def __le__(self, other):
+        return self._weight <= other._weight
+
     def __gt__(self, other):
-        if self.getWeight() > other.getWeight():
-            return True
-        else:
-            return False
+        return self._weight > other._weight
 
     def __ge__(self, other):
-        if self.getWeight() >= other.getWeight():
-            return True
-        else:
-            return False
+        return self._weight >= other._weight
 
     @property
     def __geo_interface__(self):


### PR DESCRIPTION
This change improves performance by hoisting a maxDistFromNode() call out of an inner loop, which caused a 90x gain. The remaining speedups were due to precomputing buildAssocDict(), and using a set() to track visited nodes during a depth-first search. This change also cleans up object protocol methods on Node and Seg, to improve readability while offering modest performance gains. 